### PR TITLE
make wapi.js version configurable starting from 2.0.0

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -136,8 +136,12 @@ class WhatsAPIDriver(object):
 
     def __init__(self, client="firefox", username="API", proxy=None, command_executor=None, loadstyles=False,
                  profile=None, headless=False, autoconnect=True, logger=None, extra_params=None, chrome_options=None,
-                 executable_path=None, script_timeout=60, element_timeout=30, license_key=None):
+                 executable_path=None, script_timeout=60, element_timeout=30, license_key=None, wapi_version="master"):
         """Initialises the webdriver"""
+        """
+            Note:
+            wapi_version: see https://github.com/open-wa/wa-automate-nodejs/releases, configurable starting from 2.0.0
+        """
 
         self.logger = logger or self.logger
         self.license_key = license_key
@@ -226,7 +230,7 @@ class WhatsAPIDriver(object):
 
             if headless:
                 options.headless = True
-            
+
             capabilities = DesiredCapabilities.FIREFOX.copy()
             self.driver = webdriver.Remote(
                 command_executor=command_executor,
@@ -238,7 +242,7 @@ class WhatsAPIDriver(object):
         else:
             self.logger.error("Invalid client: %s" % client)
         self.username = username
-        self.wapi_functions = WapiJsWrapper(self.driver, self)
+        self.wapi_functions = WapiJsWrapper(self.driver, self, wapi_version)
 
         self.driver.set_script_timeout(script_timeout)
         self.element_timeout = element_timeout

--- a/src/wapi_js_wrapper.py
+++ b/src/wapi_js_wrapper.py
@@ -25,10 +25,11 @@ class WapiJsWrapper(object):
     Wraps JS functions in window.WAPI for easier use from python
     """
 
-    def __init__(self, driver, wapi_driver):
+    def __init__(self, driver, wapi_driver, wapi_version="master"):
         self.driver = driver
         self.wapi_driver = wapi_driver
         self.available_functions = None
+        self.wapi_version = wapi_version
 
         # Starts new messages observable thread.
         self.new_messages_observable = NewMessagesObservable(self, wapi_driver, driver)
@@ -67,10 +68,12 @@ class WapiJsWrapper(object):
 
         result = self.driver.execute_script("if (document.querySelector('*[data-icon=chat]') !== null) { return true } else { return false }")
         if result:
-            wapi_js = requests.get('https://raw.githubusercontent.com/open-wa/wa-automate-nodejs/master/src/lib/wapi.js')
+            wapi_url = 'https://raw.githubusercontent.com/open-wa/wa-automate-nodejs/{}/src/lib/wapi.js'.format(self.wapi_version)
+            wapi_js = requests.get(wapi_url)
             self.driver.execute_script(wapi_js.content.decode())
 
-            patches = json.loads(requests.get('https://raw.githubusercontent.com/open-wa/wa-automate-nodejs/master/patches.json').content.decode())
+            patch_url = 'https://raw.githubusercontent.com/open-wa/wa-automate-nodejs/{}/patches.json'.format(self.wapi_version)
+            patches = json.loads(requests.get(patch_url).content.decode())
             for patch in patches:
                 self.driver.execute_script(patch)
 


### PR DESCRIPTION
Make wapi.js version configurable

Reason:
When the wapi.js from https://github.com/open-wa/wa-automate-nodejs introduced a breaking changes, the user of this library can choose to use the older version of wapi.js rather than waiting a maintainer/contributor to push the changes, which may go unnoticed for few hours.
Example of the use case is when wapi.js is bumped to 2.0.0, needing the implementation of patch system on the library.

Limitation:
The `wapi_version` option should only uses 2.0.0 or newer as we will try to match wapi.js version in order to avoid issues

Wxample usage:
```WhatsAPIDriver(wapi_version="2.0.0")```
version is taken from release tag: https://github.com/open-wa/wa-automate-nodejs/releases