### PR TITLE
Fix QR Reloader

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -74,7 +74,7 @@ class WhatsAPIDriver(object):
     _SELECTORS = {
         'qrCode': "canvas[aria-label=\"Scan me!\"]",
         'qrCodePlain': "div[data-ref]",
-        'QRReloader': 'div[data-ref] > span > div',
+        'QRReloader': 'div[data-ref] > span > button',
         'mainPage': ".two",
     }
 


### PR DESCRIPTION
`reload_qr` seems to be broken for me and it seems whatsapp changed the element from div to button. This change seems to fix it for me.

Tested browser:
- Firefox 77

Please test in on chrome as I don't have a chromedriver set up.