### PR TITLE
Feature: Chrome remote webdriver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ driver = WhatsAPIDriver()
 
 Possible arguments for constructor:
 
-- client : Type of browser. The default is Firefox, but Chrome and Remote is supported too. See sample directory for remote examples.
+- client : Type of browser. The default is `firefox`, but `chrome` is also supported.
+- remote: Defines if webdriver will be loaded as remote. See sample directory for remote examples.
 - username : Can be any value.
 - proxy: The proxy server to configure selenium to. Format is "<proxy>:<portnumber>"
 - command_executor: Passed directly as an argument to Remote Selenium. Ignore if not using it. See sample directory for remote examples. 

--- a/sample/new_messages_observer.py
+++ b/sample/new_messages_observer.py
@@ -13,7 +13,7 @@ def run():
         print("Please set the environment variable SELENIUM to Selenium URL")
         sys.exit(1)
 
-    driver = WhatsAPIDriver(client='remote', command_executor=os.environ["SELENIUM"])
+    driver = WhatsAPIDriver(client='firefox', remote=True, command_executor=os.environ["SELENIUM"])
     print("Waiting for QR")
     driver.wait_for_login()
     print("Bot started")

--- a/sample/remote.py
+++ b/sample/remote.py
@@ -15,7 +15,7 @@ except KeyError:
 ##The profile parameter requires a directory not a file.
 profiledir = os.path.join(".", "firefox_cache")
 if not os.path.exists(profiledir): os.makedirs(profiledir)
-driver = WhatsAPIDriver(profile=profiledir, client='remote', command_executor=os.environ["SELENIUM"])
+driver = WhatsAPIDriver(profile=profiledir, client='firefox', remote=True, command_executor=os.environ["SELENIUM"])
 print("Waiting for QR")
 driver.wait_for_login()
 print("Saving session")


### PR DESCRIPTION
I've created a new class attribute called `remote` that defines if the webdrive will be initialized as a remote connection. Now, the user can choose between `firefox` and `chrome` and set if it will be a remote connections parsing `remote=True`. I've maintained the client `remote` for compatibility, but added a warning saying that `remote` client is deprecated.

Also updated the docs and the samples.

Tested it on my environment using docker-compose with `selenium/standalone-chrome:4.0.0` image.